### PR TITLE
First reply not showing as a reply on Twitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "find-port-free-sync": "^1.0.1",
     "howsmydriving-dummy": "^0.1.46",
     "howsmydriving-seattle": "^0.1.43",
-    "howsmydriving-twitter": "^0.1.42",
+    "howsmydriving-twitter": "^0.1.45",
     "howsmydriving-utils": "^0.1.96",
     "log4js": "^4.0.2",
     "mutex": "^1.0.4",

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -6,7 +6,7 @@ dependencies:
   find-port-free-sync: 1.0.1
   howsmydriving-dummy: 0.1.46
   howsmydriving-seattle: 0.1.43
-  howsmydriving-twitter: 0.1.42
+  howsmydriving-twitter: 0.1.45
   howsmydriving-utils: 0.1.96
   log4js: 4.5.1
   mutex: 1.0.4
@@ -2719,6 +2719,22 @@ packages:
       node: 10.x
     resolution:
       integrity: sha512-pkU+K1Iy0fCo339g2GDcxpRFSdWpHas51OI2la9FxoD1pz8EhpfjylQAdIjxxPMllwWTkL3mQq5knDI7y1xV9A==
+  /howsmydriving-twitter/0.1.45:
+    dependencies:
+      chokidar: 3.3.1
+      file-system: 2.2.2
+      howsmydriving-utils: 0.1.96
+      log4js: 4.5.1
+      mutex-promise: 0.1.0
+      packpath: 0.1.0
+      soap: 0.30.0
+      twit: 2.2.11
+      uuid: 3.3.3
+    dev: false
+    engines:
+      node: 10.x
+    resolution:
+      integrity: sha512-+hVIGgSR810FX11NYe5Wi2TCwNWdhI2PQ5UFLWTXQuvJsX7/ajU17jw+aZFSfUsy0IEnoP9urvS0UcwsM9zZjQ==
   /howsmydriving-utils/0.1.96:
     dependencies:
       '@types/node': 12.12.22
@@ -6219,7 +6235,7 @@ specifiers:
   gulp-typescript: ^6.0.0-alpha.1
   howsmydriving-dummy: ^0.1.46
   howsmydriving-seattle: ^0.1.43
-  howsmydriving-twitter: ^0.1.42
+  howsmydriving-twitter: ^0.1.45
   howsmydriving-utils: ^0.1.96
   log4js: ^4.0.2
   mocha: ^6.2.2

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -48,7 +48,7 @@ export class ReportItemRecord implements IReportItemRecord {
     this.license = citation.license;
     this.region = citation.region;
     this.tweet_id = citation.tweet_id;
-    this.tweet_id_str = citation.tweet_user_screen_name;
+    this.tweet_id_str = citation.tweet_id_str;
     this.tweet_user_screen_name = citation.tweet_user_screen_name;
     this.processing_status = 'UNPROCESSED';
     this.created = now;


### PR DESCRIPTION
Report records were being written with tweet_id_str as the tweet_user_screen_name which made the screen name show up in the tweet so it almost looked like a reply, but it wasn't because when posting the reply, in_reply_to_status_id was not a valid tweet.id_str but a user screen name.

Fixes #107 