### PR TITLE
Add unique number to all 'no plate found' tweets to ensure tweet uniqueness

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "aws-sdk": "^2.578.0",
     "chokidar": "^3.3.0",
+    "consecutive": "^5.0.5",
     "dynamo-batchwrite-queue": "^1.0.1",
     "express": "^4.14.0",
     "find-port-free-sync": "^1.0.1",

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -1,6 +1,7 @@
 dependencies:
   aws-sdk: 2.590.0
   chokidar: 3.3.1
+  consecutive: 5.0.5
   dynamo-batchwrite-queue: 1.0.1
   express: 4.17.1
   find-port-free-sync: 1.0.1
@@ -1009,6 +1010,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-lRO5W81An0LsKuVAoAER0jqZuaI=
+  /consecutive/5.0.5:
+    dev: false
+    resolution:
+      integrity: sha512-mx9vRmvKStKCsPf9vLipVK6k3W44gam+HBQ4S1CfGdcMCm2QqZ7swd2cxczkd7VlVf5PrHVW4zDIhG7wH6P3LA==
   /content-disposition/0.5.3:
     dependencies:
       safe-buffer: 5.1.2
@@ -6204,6 +6209,7 @@ specifiers:
   aws-sdk: ^2.578.0
   aws-sdk-mock: ^4.5.0
   chokidar: ^3.3.0
+  consecutive: ^5.0.5
   del: ^5.1.0
   dynamo-batchwrite-queue: ^1.0.1
   express: ^4.14.0

--- a/src/server.ts
+++ b/src/server.ts
@@ -1993,7 +1993,3 @@ function WriteReportItemRecords(
     report_item_records
   );
 }
-
-function sleep(milliseconds: number) {
-  return new Promise(resolve => setTimeout(resolve, milliseconds));
-};

--- a/src/server.ts
+++ b/src/server.ts
@@ -1546,9 +1546,6 @@ function GetReportItemForPseudoCitation(
   if (!citation || citation.citation_id >= CitationIds.MINIMUM_CITATION_ID) {
     throw new Error(`ERROR: Unexpected citation ID: ${citation.citation_id}.`);
   }
-
-  var msg: string;
-
   switch (citation.citation_id) {
     case CitationIds.CitationIDNoPlateFound:
       // We need to ensure that we never create 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@
 import * as AWS from 'aws-sdk';
 import { DocumentClient, QueryOutput } from 'aws-sdk/clients/dynamodb';
 import { Request, Response } from 'express';
+import * as consecutive from 'consecutive';
 import * as http from 'http';
 import * as uuid from 'uuid';
 import * as mutex from 'mutex';
@@ -48,6 +49,7 @@ const express = require('express'),
 
 // Local storage to keep track of our last processed tweet/dm
 var localStorage = new LocalStorage('./.localstore');
+const next_unique_number = consecutive();
 
 // packpath.self() does not seem to work for a top-level app.
 // Just use packpath.parent{} which is /app.
@@ -914,20 +916,24 @@ function processRequestRecords(): Promise<void> {
                 tableNames['Citations'],
                 citation_records
               ).then(() => {
-                let msg: string = 'Finished writing:';
+                let total_citations: number = 0;
+                let msg: string = '';
 
                 Object.keys(citations_written).forEach(request_id => {
                   Object.keys(citations_written[request_id]).forEach(
                     region_name => {
                       if (region_name === 'Invalid Plate') {
                         msg += `\n  1 citations for request ${request_id} invalid plate in Global region.`;
+                        total_citations += 1;
                       } else {
                         msg += `\n  ${citations_written[request_id][region_name]} citations for request ${request_id} ${licenses[request_id]} in ${region_name} region.`;
+                        total_citations += citations_written[request_id][region_name];
                       }
                     }
                   );
                 });
 
+                msg = 'Finished writing ${total_citations} citation records:' + msg
                 log.info(msg);
 
                 var request_update_records: Array<any> = [];
@@ -1096,7 +1102,6 @@ function processCitationRecords(): Promise<void> {
                         region_name,
                         license_query_hash[citation.license]
                       );
-
                       report_items.push(
                         new ReportItemRecord(message, 0, citation)
                       );
@@ -1542,13 +1547,17 @@ function GetReportItemForPseudoCitation(
     throw new Error(`ERROR: Unexpected citation ID: ${citation.citation_id}.`);
   }
 
+  var msg: string;
+
   switch (citation.citation_id) {
     case CitationIds.CitationIDNoPlateFound:
-      return noValidPlate.replace('__DATETIME__', `[${new Date().toDateString()} ${new Date().toLocaleTimeString()}]`);
+      // We need to ensure that we never create 
+      let now = new Date();
+      return noValidPlate.replace('__DATETIME__', `[${now.toDateString()} ${now.toLocaleTimeString()}:${now.getMilliseconds()} [${next_unique_number()}]]`);
       break;
 
     case CitationIds.CitationIDNoCitationsFound:
-      return (
+      return
         noCitationsFoundMessage
           .replace('__LICENSE__', formatPlate(citation.license))
           .replace('__REGION_NAME__', region_name) +
@@ -1556,7 +1565,6 @@ function GetReportItemForPseudoCitation(
         citationQueryText
           .replace('__LICENSE__', formatPlate(citation.license))
           .replace('__COUNT__', query_count.toString())
-      );
       break;
 
     default:
@@ -1988,3 +1996,7 @@ function WriteReportItemRecords(
     report_item_records
   );
 }
+
+function sleep(milliseconds: number) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+};


### PR DESCRIPTION
There is a possibility that even with the date/time in there, if we generate 2 within the same ms, they will be unique. This makes that all but impossible.